### PR TITLE
fix: Fixed so that items with reduced durability value do not lose their effects

### DIFF
--- a/src/main/kotlin/dev/m1sk9/ribbon/ExecuteItem.kt
+++ b/src/main/kotlin/dev/m1sk9/ribbon/ExecuteItem.kt
@@ -18,6 +18,7 @@ abstract class ExecuteItem(
         meta.displayName(Component.text(name))
         meta.lore(lore.map { Component.text(it) })
         meta.addEnchant(Enchantment.UNBREAKING, 1, true)
+        meta.isUnbreakable = true
 
         item.itemMeta = meta
         return item


### PR DESCRIPTION
When the durability value decreased, the metadata of the item inside changed and it lost its original function. Change metadata so that durability values do not decrease